### PR TITLE
fix: SampleData(Order)에 DeliverId null로 뜨는거 해결 & 주문 취소시 해당 delivery 연결 끊기

### DIFF
--- a/src/main/java/org/team6/coffeebeanery/common/data/DeliveryTestDataUtils.java
+++ b/src/main/java/org/team6/coffeebeanery/common/data/DeliveryTestDataUtils.java
@@ -26,7 +26,10 @@ public class DeliveryTestDataUtils {
                 delivery.setDeliveryNumber(generateDeliveryNumber());
                 delivery.setDeliveryCompany(generateDeliveryCompany());
                 delivery.setOrder(order); // Order와 Delivery 연결
+                order.setDelivery(delivery); // Order에 Delivery 정보 기입
+
                 deliveryRepository.save(delivery);
+                orderRepository.save(order);
             }
         }
     }

--- a/src/main/java/org/team6/coffeebeanery/common/data/DeliveryTestDataUtils.java
+++ b/src/main/java/org/team6/coffeebeanery/common/data/DeliveryTestDataUtils.java
@@ -20,8 +20,8 @@ public class DeliveryTestDataUtils {
 
         for (int i = 0; i < orders.size(); i++) {
             Order order = orders.get(i);
-            // 주문 취소 상태가 아닌 경우에만 배송 정보 생성
-            if (order.getOrderStatus() != OrderStatus.CANCELLED) {
+            // 배송 정보는 PREPARING, DELIVERED에만 있어야 정상
+            if (order.getOrderStatus() == OrderStatus.PREPARING || order.getOrderStatus() == OrderStatus.DELIVERED) {
                 Delivery delivery = new Delivery();
                 delivery.setDeliveryNumber(generateDeliveryNumber());
                 delivery.setDeliveryCompany(generateDeliveryCompany());

--- a/src/main/java/org/team6/coffeebeanery/order/service/BuyerOrderService.java
+++ b/src/main/java/org/team6/coffeebeanery/order/service/BuyerOrderService.java
@@ -6,6 +6,7 @@ import org.team6.coffeebeanery.common.constant.OrderStatus;
 import org.team6.coffeebeanery.common.exception.InvalidInputException;
 import org.team6.coffeebeanery.common.exception.ResourceNotFoundException;
 import org.team6.coffeebeanery.common.model.Address;
+import org.team6.coffeebeanery.delivery.model.Delivery;
 import org.team6.coffeebeanery.order.converter.OrderConverter;
 import org.team6.coffeebeanery.order.dto.OrderCreateReqBody;
 import org.team6.coffeebeanery.order.dto.OrderDTO;
@@ -84,6 +85,12 @@ public class BuyerOrderService {
                         "order not found - id: " + orderId));
 
         if(order.getOrderStatus().equals(OrderStatus.ORDERED)) {
+            // 주문에 배송 정보가 있다면 연관관계 제거
+            if (order.getDelivery() != null) {
+                Delivery delivery = order.getDelivery();
+                delivery.setOrder(null);
+                order.setDelivery(null);
+            }
             order.setOrderStatus(OrderStatus.CANCELLED);
         } else {
             throw new InvalidInputException("주문 취소는 배송 전에만 가능합니다.");

--- a/src/main/java/org/team6/coffeebeanery/order/service/BuyerOrderService.java
+++ b/src/main/java/org/team6/coffeebeanery/order/service/BuyerOrderService.java
@@ -1,23 +1,22 @@
 package org.team6.coffeebeanery.order.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.team6.coffeebeanery.common.constant.OrderStatus;
 import org.team6.coffeebeanery.common.exception.InvalidInputException;
 import org.team6.coffeebeanery.common.exception.ResourceNotFoundException;
 import org.team6.coffeebeanery.common.model.Address;
-import org.team6.coffeebeanery.delivery.model.Delivery;
 import org.team6.coffeebeanery.order.converter.OrderConverter;
 import org.team6.coffeebeanery.order.dto.OrderCreateReqBody;
 import org.team6.coffeebeanery.order.dto.OrderDTO;
 import org.team6.coffeebeanery.order.model.Order;
 import org.team6.coffeebeanery.order.repository.OrderDetailRepository;
 import org.team6.coffeebeanery.order.repository.OrderRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.team6.coffeebeanery.product.dto.ProductDTO;
 import org.team6.coffeebeanery.product.model.Product;
 import org.team6.coffeebeanery.product.service.SellerProductService;
@@ -78,6 +77,7 @@ public class BuyerOrderService {
         }
     }
 
+    // 주문 취소
     @Transactional
     public void cancelOrder(Long orderId) {
         Order order = orderRepository.findById(orderId)
@@ -85,12 +85,6 @@ public class BuyerOrderService {
                         "order not found - id: " + orderId));
 
         if(order.getOrderStatus().equals(OrderStatus.ORDERED)) {
-            // 주문에 배송 정보가 있다면 연관관계 제거
-            if (order.getDelivery() != null) {
-                Delivery delivery = order.getDelivery();
-                delivery.setOrder(null);
-                order.setDelivery(null);
-            }
             order.setOrderStatus(OrderStatus.CANCELLED);
         } else {
             throw new InvalidInputException("주문 취소는 배송 전에만 가능합니다.");


### PR DESCRIPTION
다시 수정
1. 샘플 데이터 생성 시 Order에 DeliveryId null로 뜨는거 수정
 - 샘플 데이터에서 Id 1,4번 주문은 애초에 샘플 데이터 만들떄부터  ORDERED, CANCELLED 여서 DeliveryId는 null로 뜨는게 정상입니다.
 
 2. 주문 취소 로직은 애초에 ORDERED인 주문은 delivery정보가 없으니  null 처리 할 필요 없음.